### PR TITLE
Fix issue where concurrent threads overwrite the parameter information.

### DIFF
--- a/garisom_tools/model.py
+++ b/garisom_tools/model.py
@@ -536,6 +536,10 @@ class GarisomModel(Model):
             - Automatically determines output filename based on species/region/site IDs
             - Preserves original parameters DataFrame (modifications are local)
         """
+
+        # Make a deep copy to preserve the original DataFrame
+        params = params.copy(deep=True)
+
         with TemporaryDirectory() as tmp:
             TMP_PARAM_FILE = f"{tmp}/params.csv"
 


### PR DESCRIPTION
Now a deepcopy is made for the parameter file whenever parameters are overwritten, preserving the original parameter DataFrame in parallel model executions.